### PR TITLE
Use "UTF-8" instead of "utf8" to avoid locale warnings

### DIFF
--- a/choosedialog.cpp
+++ b/choosedialog.cpp
@@ -31,9 +31,11 @@ void chooseDialog::setup()
 void chooseDialog::buildLocaleList()
 {
     QFile libFile("/usr/lib/mx-locale/locale.lib");
-
-    QString locales = Cmd().getOut(R"(env LANG=C LC_ALL=C locale --all-locales | grep -E '[.](utf8|UTF-8)')");
-    QStringList availableLocales = locales.split(QRegularExpression(R"((\r\n)|(\n\r)|\r|\n)"), Qt::SkipEmptyParts);
+    QString locales = Cmd().getOut(R"(locale --all-locales)");
+    QStringList availableLocales = locales
+                                   .split(QRegularExpression(R"((\r\n)|(\n\r)|\r|\n)"), Qt::SkipEmptyParts)
+                                   .filter(QRegularExpression(R"([.](utf8|UTF-8))"))
+                                   .replaceInStrings(".utf8", ".UTF-8", Qt::CaseInsensitive);
 
     if (!libFile.open(QIODevice::ReadOnly)) {
         QMessageBox::critical(nullptr, tr("Error"),

--- a/cmd.cpp
+++ b/cmd.cpp
@@ -43,9 +43,9 @@ bool Cmd::run(const QString &cmd, bool quiet, bool asRoot)
     QEventLoop loop;
     connect(this, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), &loop, &QEventLoop::quit);
     if (asRoot && getuid() != 0) {
-        start(elevate, {helper, "LC_ALL=C.utf8 " + cmd});
+        start(elevate, {helper, "export LC_ALL=C.UTF-8; " + cmd});
     } else {
-        start("/bin/bash", {"-c", "LC_ALL=C.utf8 " + cmd});
+        start("/bin/bash", {"-c", "export LC_ALL=C.UTF-8; " + cmd});
     }
     loop.exec();
     emit done();

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mx-locale (24.1.15) mx; urgency=medium
+
+  * Use "UTF-8" instead of "utf8" to avoid locale warnings
+
+ -- fehlix <fehlix@mxlinux.org>  Sun, 28 Jan 2024 14:03:08 -0500
+
 mx-locale (24.1.14) mx; urgency=medium
 
   * Fix crash when pressing OK without selecting any item


### PR DESCRIPTION
This is about to avoid such warnings like the one shown in "View changelog":

`/bin/bash: warning: setlocale: LC_ALL: cannot change locale (C.utf8)`
or when locale command is used
```
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_COLLATE to default locale: No such file or directory
```
This can happen in case the locale used was not generated within the locale archive
but instead generated within a locale directory and uppercase UTF-8 was used for the directory name.
Example would be on bullseye C.UTF-8, where LC_ALL=C.utf8 created such error-/warnings.
